### PR TITLE
Updated to provide read acl permission on the bucket created for the use...

### DIFF
--- a/lib/riak_cs_broker/service_instances.rb
+++ b/lib/riak_cs_broker/service_instances.rb
@@ -169,8 +169,9 @@ module RiakCsBroker
       grantee_hash             = { 'ID' => user_id }
       write_grant              = { 'Permission' => 'WRITE', 'Grantee' => grantee_hash }
       read_grant               = { 'Permission' => 'READ', 'Grantee' => grantee_hash }
+      read_acp_grant           = { 'Permission' => 'READ_ACP', 'Grantee' => grantee_hash }
       acl                      = @storage_client.get_bucket_acl(bucket_name).body
-      acl['AccessControlList'] += [read_grant, write_grant]
+      acl['AccessControlList'] += [read_grant, write_grant, read_acp_grant]
       @storage_client.put_bucket_acl(bucket_name, acl)
     end
 


### PR DESCRIPTION
...r

This is required to use the RiakCS BlobStore using JCloud Blobstore libraries. The library requires permission to access the acls on the bucket before it can put a new object in it.

Below is the exception thrown by JCloud's BlobStore library indicating the same. This fix resolves it. 

2015-02-11T21:34:28.92-0800 [App/0]   OUT 2015-02-12 05:34:28.920 ERROR 31 --- [o-61082-exec-10] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is com.google.common.util.concurrent.UncheckedExecutionException: org.jclouds.rest.AuthorizationException: Access Denied] with root cause
2015-02-11T21:34:28.92-0800 [App/0]   OUT org.jclouds.aws.AWSResponseException: request GET https://p-riakcs.10.244.0.34.xip.io/service-instance-9329d598-4c8a-470b-8eba-89dd9759cf0a?acl HTTP/1.1 failed with code 403, error: AWSError{requestId='', requestToken='null', code='AccessDenied', message='Access Denied', context='{Resource=/service-instance-9329d598-4c8a-470b-8eba-89dd9759cf0a}'}
2015-02-11T21:34:28.92-0800 [App/0]   OUT 	at org.jclouds.aws.handlers.ParseAWSErrorFromXmlContent.handleError(ParseAWSErrorFromXmlContent.java:77)
2015-02-11T21:34:28.92-0800 [App/0]   OUT 	at org.jclouds.http.handlers.DelegatingErrorHandler.handleError(DelegatingErrorHandler.java:67)
2015-02-11T21:34:28.92-0800 [App/0]   OUT 	at org.jclouds.http.internal.BaseHttpCommandExecutorService.shouldContinue(BaseHttpCommandExecutorService.java:180)
2015-02-11T21:34:28.92-0800 [App/0]   OUT 	at org.jclouds.http.internal.BaseHttpCommandExecutorService.invoke(BaseHttpCommandExecutorService.java:150)
2015-02-11T21:34:28.92-0800 [App/0]   OUT 	at org.jclouds.rest.internal.InvokeSyncToAsyncHttpMethod.invoke(InvokeSyncToAsyncHttpMethod.java:129)
2015-02-11T21:34:28.92-0800 [App/0]   OUT 	at org.jclouds.rest.internal.InvokeSyncToAsyncHttpMethod.apply(InvokeSyncToAsyncHttpMethod.java:95)
2015-02-11T21:34:28.92-0800 [App/0]   OUT 	at org.jclouds.rest.internal.InvokeSyncToAsyncHttpMethod.apply(InvokeSyncToAsyncHttpMethod.java:56)
2015-02-11T21:34:28.92-0800 [App/0]   OUT 	at org.jclouds.rest.internal.DelegatesToInvocationFunction.handle(DelegatesToInvocationFunction.java:156)
2015-02-11T21:34:28.92-0800 [App/0]   OUT 	at org.jclouds.rest.internal.DelegatesToInvocationFunction.invoke(DelegatesToInvocationFunction.java:123)
2015-02-11T21:34:28.92-0800 [App/0]   OUT 	at com.sun.proxy.$Proxy70.getBucketACL(Unknown Source)