### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Based on [the Riak service broker by @hectcastro](https://github.com/hectcastro/
 ### Prerequisites
 
 This service broker must be configured to access a Riak CS cluster.
-You can use Bosh to deploy such a cluster alongside Cloud Foundry, or it can be deployed locally by [bosh-lite](https://github.com/cloudfoundry/bosh-lite) for development purposes. Deploying this as a standalone application to cloud foundry (e.g. via `cf push`) is not supported. A Bosh release for Riak and Riak CS can be found [here](https://github.com/cloudfoundry-incubator/cf-riak-cs-release).
+You can use Bosh to deploy such a cluster alongside Cloud Foundry, or it can be deployed locally by [bosh-lite](https://github.com/cloudfoundry/bosh-lite) for development purposes. Deploying this as a standalone application to cloud foundry (e.g. via `cf push`) is not supported. A Bosh release for Riak and Riak CS can be found [here](https://github.com/cloudfoundry/cf-riak-cs-release).
 
 ### Testing
 


### PR DESCRIPTION
Link pointing to the cloudfoundry repository instead of cloudfoundry-incubator.
